### PR TITLE
Ability to provide a separate instance of HeapFriendlyMapArrayRecyler

### DIFF
--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/AbstractHeapFriendlyMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/AbstractHeapFriendlyMap.java
@@ -57,8 +57,7 @@ public abstract class AbstractHeapFriendlyMap<K, V> extends AbstractMap<K, V> {
 
     public abstract void releaseObjectArrays();
 
-    protected void releaseObjectArrays(Object[][] segmentedArray) {
-        HeapFriendlyMapArrayRecycler recycler = HeapFriendlyMapArrayRecycler.get();
+    protected void releaseObjectArrays(Object[][] segmentedArray, HeapFriendlyMapArrayRecycler recycler) {
 
         for(int i=0;i<segmentedArray.length;i++) {
             recycler.returnObjectArray(segmentedArray[i]);

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyDerivableKeyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyDerivableKeyHashMap.java
@@ -45,6 +45,8 @@ public abstract class HeapFriendlyDerivableKeyHashMap<K, V> extends AbstractHeap
     private final Object[][] values;
     private final int numBuckets;
     private final int maxSize;
+    private final HeapFriendlyMapArrayRecycler recycler;
+    
     private int size;
 
     protected HeapFriendlyDerivableKeyHashMap(int numEntries) {
@@ -54,13 +56,12 @@ public abstract class HeapFriendlyDerivableKeyHashMap<K, V> extends AbstractHeap
 
         this.numBuckets = arraySize;
         this.maxSize = numEntries;
+        this.recycler = HeapFriendlyMapArrayRecycler.get();
         values = createSegmentedObjectArray(arraySize);
     }
 
     private Object[][] createSegmentedObjectArray(int arraySize) {
         int numArrays = arraySize / INDIVIDUAL_OBJECT_ARRAY_SIZE;
-
-        HeapFriendlyMapArrayRecycler recycler = HeapFriendlyMapArrayRecycler.get();
 
         Object[][] segmentedArray = new Object[numArrays][];
 
@@ -147,7 +148,7 @@ public abstract class HeapFriendlyDerivableKeyHashMap<K, V> extends AbstractHeap
 
     @Override
     public void releaseObjectArrays() {
-        releaseObjectArrays(values);
+        releaseObjectArrays(values, recycler);
     }
 
     @Override

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyHashMap.java
@@ -40,15 +40,21 @@ public class HeapFriendlyHashMap<K, V> extends AbstractHeapFriendlyMap<K, V> {
     private final Object[][] values;
     private final int numBuckets;
     private final int maxSize;
+    private final HeapFriendlyMapArrayRecycler recycler;
     private int size;
 
     public HeapFriendlyHashMap(int numEntries) {
+        this(numEntries, HeapFriendlyMapArrayRecycler.get());
+    }
+
+    public HeapFriendlyHashMap(int numEntries, HeapFriendlyMapArrayRecycler recycler) {
         int arraySize = numEntries * 10 / 7; // 70% load factor
         arraySize = 1 << (32 - Integer.numberOfLeadingZeros(arraySize)); // next power of 2
         arraySize = Math.max(arraySize, INDIVIDUAL_OBJECT_ARRAY_SIZE);
 
         this.numBuckets = arraySize;
         this.maxSize = numEntries;
+        this.recycler = recycler;
         this.keys = createSegmentedObjectArray(arraySize);
         this.values = createSegmentedObjectArray(arraySize);
     }
@@ -231,8 +237,8 @@ public class HeapFriendlyHashMap<K, V> extends AbstractHeapFriendlyMap<K, V> {
 
     @Override
     public void releaseObjectArrays() {
-        releaseObjectArrays(keys);
-        releaseObjectArrays(values);
+        releaseObjectArrays(keys, recycler);
+        releaseObjectArrays(values, recycler);
     }
 
     private static class Entry<K, V> extends AbstractHeapFriendlyMapEntry<K, V> {

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyHashMap.java
@@ -241,10 +241,6 @@ public class HeapFriendlyHashMap<K, V> extends AbstractHeapFriendlyMap<K, V> {
         releaseObjectArrays(values, recycler);
     }
 
-    public HeapFriendlyMapArrayRecycler getRecycler() {
-        return recycler;
-    }
-
     private static class Entry<K, V> extends AbstractHeapFriendlyMapEntry<K, V> {
         private final K key;
         private final V value;

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyHashMap.java
@@ -241,6 +241,10 @@ public class HeapFriendlyHashMap<K, V> extends AbstractHeapFriendlyMap<K, V> {
         releaseObjectArrays(values, recycler);
     }
 
+    public HeapFriendlyMapArrayRecycler getRecycler() {
+        return recycler;
+    }
+
     private static class Entry<K, V> extends AbstractHeapFriendlyMapEntry<K, V> {
         private final K key;
         private final V value;


### PR DESCRIPTION
Added the ability in HeapFriendlyHashMap to provide a separate instance of HeapFriendlyMapArrayRecyler.