### PR TITLE
Phased heapfriendly hashmap

### DIFF
--- a/src/examples/java/com/netflix/zeno/examples/PhasedHeapFriendlyHashMapExample.java
+++ b/src/examples/java/com/netflix/zeno/examples/PhasedHeapFriendlyHashMapExample.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  Copyright 2013 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.zeno.examples;
+
+import com.netflix.zeno.util.collections.heapfriendly.PhasedHeapFriendlyHashMap;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Example usage of {@link PhasedHeapFriendlyHashMap}
+ * 
+ * @author drbathgate
+ *
+ */
+public class PhasedHeapFriendlyHashMapExample {
+
+    @Test
+    public void runExample() {
+        PhasedHeapFriendlyHashMap<Integer, String> map = new PhasedHeapFriendlyHashMap<Integer, String>();
+
+        fillMap(map, 1, 2, 3, 4, 5, 6, 7, 8);
+        printMapEntries(map);
+
+        fillMap(map, 1, 2, 3, 4, 5, 6, 7, 9);
+        printMapEntries(map);
+
+        fillMap(map, 1, 2, 3, 4, 5, 6, 7, 10);
+        printMapEntries(map);
+
+        fillMap(map, 1, 2, 3, 4, 5, 6, 7, 11);
+        printMapEntries(map);
+
+    }
+
+    private void fillMap(PhasedHeapFriendlyHashMap<Integer, String> map, int... entries) {
+
+        // allow access to put data by starting data swap phase
+        map.beginDataSwapPhase(entries.length);
+
+        for(int entry: entries) {
+
+            // entries will not be available until the end of the data swap phase
+            map.put(entry, String.valueOf(entry));
+        }
+
+        // make data available by ending data swap phase
+        map.endDataSwapPhase();
+    }
+
+    private void printMapEntries(PhasedHeapFriendlyHashMap<Integer, String> map) {
+        for(Map.Entry<Integer, String> entry : map.entrySet()) {
+            System.out.println(entry.getKey() + ":\"" + entry.getValue() + "\"");
+        }
+    }
+}

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyDerivableKeyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyDerivableKeyHashMap.java
@@ -60,7 +60,7 @@ public abstract class HeapFriendlyDerivableKeyHashMap<K, V> extends AbstractHeap
 
         this.numBuckets = arraySize;
         this.maxSize = numEntries;
-        this.recycler = HeapFriendlyMapArrayRecycler.get();
+        this.recycler = recycler;
         values = createSegmentedObjectArray(arraySize);
     }
 

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/HeapFriendlyHashMap.java
@@ -62,8 +62,6 @@ public class HeapFriendlyHashMap<K, V> extends AbstractHeapFriendlyMap<K, V> {
     private Object[][] createSegmentedObjectArray(int arraySize) {
         int numArrays = arraySize / INDIVIDUAL_OBJECT_ARRAY_SIZE;
 
-        HeapFriendlyMapArrayRecycler recycler = HeapFriendlyMapArrayRecycler.get();
-
         Object[][] segmentedArray = new Object[numArrays][];
 
         for(int i=0;i<numArrays;i++) {

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMap.java
@@ -122,6 +122,11 @@ public class PhasedHeapFriendlyHashMap<K, V> implements Map<K, V> {
      * @param numOfNewEntries Number of new entries expected to be added during the the data swap phase
      */
     public void beginDataSwapPhase(int numOfNewEntries){
+
+        if (nextMap != null) {
+            throw new IllegalStateException("Cannot call PhasedHeapFriendlyHashMap.beginDataSwapPhase(int), already in data swap phase");
+        }
+
         recycler.swapCycleObjectArrays();
 
         nextMap = new HeapFriendlyHashMap<K, V>(numOfNewEntries, recycler);
@@ -134,6 +139,10 @@ public class PhasedHeapFriendlyHashMap<K, V> implements Map<K, V> {
      * will throw an {@link IllegalStateException} <p />
      */
     public void endDataSwapPhase(){
+
+        if (nextMap == null) {
+            throw new IllegalStateException("Cannot call PhasedHeapFriendlyHashMap.endDataSwapPhase(), not currently in data swap phase");
+        }
 
         HeapFriendlyHashMap<K, V> temp = currentMap;
 

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMap.java
@@ -1,0 +1,147 @@
+/*
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.zeno.util.collections.heapfriendly;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of {@link Map} that wraps a {@link HeapFriendlyHashMap}
+ * and exposes methods for switching in and out of a data swap phase. <p />
+ * 
+ * The data swap phase is entered by calling {@link PhasedHeapFriendlyHashMap#beginDataSwapPhase(int)} <p />
+ * 
+ * While in the data swap phase, {@link PhasedHeapFriendlyHashMap#put(Object, Object)}
+ * can be used to fill the map with data. Data will not be available until the data swap phase is complete. <p />
+ * 
+ * Calling {@link PhasedHeapFriendlyHashMap#endDataSwapPhase()} will end the
+ * data swap phase and make the data added available
+ *
+ * @author drbathgate
+ *
+ * @param <K> Key
+ * @param <V> Value
+ */
+public class PhasedHeapFriendlyHashMap<K, V> implements Map<K, V> {
+
+    private final HeapFriendlyMapArrayRecycler recycler;
+
+    private HeapFriendlyHashMap<K, V> currentMap;
+    private HeapFriendlyHashMap<K, V> nextMap;
+
+    public PhasedHeapFriendlyHashMap() {
+        this.recycler = new HeapFriendlyMapArrayRecycler();
+        this.currentMap = new HeapFriendlyHashMap<K, V>(0, recycler);
+    }
+
+    @Override
+    public int size() {
+        return currentMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return currentMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return currentMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return currentMap.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return currentMap.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        if (nextMap != null) {
+            return nextMap.put(key, value);
+        }
+
+        throw new IllegalStateException("PhasedHeapFriendlyHashMap.put(K, V) only usable when in the data swap phase");
+    }
+
+    @Override
+    public V remove(Object key) {
+        throw new UnsupportedOperationException("PhasedHeapFriendlyHashMap.remove(Object) not supported");
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        throw new UnsupportedOperationException("PhasedHeapFriendlyHashMap.putAll(Map) not supported, please use PhasedHeapFriendlyHashMap.put(Object) instead");
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("PhasedHeapFriendlyHashMap.clear() not supported");
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return currentMap.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return currentMap.values();
+    }
+
+    @Override
+    public Set<java.util.Map.Entry<K, V>> entrySet() {
+        return currentMap.entrySet();
+    }
+
+    /**
+     * Enters data swap phase<p />
+     *
+     * While in data swap phase, {@link PhasedHeapFriendlyHashMap#put(Object, Object)} can be used<p />
+     *
+     * @param numOfNewEntries Number of new entries expected to be added during the the data swap phase
+     */
+    public void beginDataSwapPhase(int numOfNewEntries){
+        recycler.swapCycleObjectArrays();
+
+        nextMap = new HeapFriendlyHashMap<K, V>(numOfNewEntries, recycler);
+    }
+
+    /**
+     * Ends the data swap phase<p />
+     *
+     * While out of the data swap phase, using {@link PhasedHeapFriendlyHashMap#put(Object, Object)}
+     * with throw an {@link IllegalStateException} <p />
+     */
+    public void endDataSwapPhase(){
+
+        HeapFriendlyHashMap<K, V> temp = currentMap;
+
+        currentMap = nextMap;
+        nextMap = null;
+
+        temp.releaseObjectArrays();
+
+        recycler.clearNextCycleObjectArrays();
+    }
+}

--- a/src/main/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMap.java
+++ b/src/main/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMap.java
@@ -131,7 +131,7 @@ public class PhasedHeapFriendlyHashMap<K, V> implements Map<K, V> {
      * Ends the data swap phase<p />
      *
      * While out of the data swap phase, using {@link PhasedHeapFriendlyHashMap#put(Object, Object)}
-     * with throw an {@link IllegalStateException} <p />
+     * will throw an {@link IllegalStateException} <p />
      */
     public void endDataSwapPhase(){
 

--- a/src/test/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMapTest.java
+++ b/src/test/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMapTest.java
@@ -1,0 +1,197 @@
+/*
+ *
+ *  Copyright 2013 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.zeno.util.collections.heapfriendly;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PhasedHeapFriendlyHashMapTest {
+
+    @Test
+    public void setAndGet() {
+        Map<String, Integer> map = getMap(30000);
+
+        for(int i=0;i<30000;i++) {
+            Assert.assertTrue(map.containsKey(String.valueOf(i)));
+            Integer val = map.get(String.valueOf(i));
+            Assert.assertEquals(i, val.intValue());
+        }
+
+        for(int i=30000;i<60000;i++) {
+            Assert.assertFalse(map.containsKey(String.valueOf(i)));
+            Assert.assertNull(map.get(String.valueOf(i)));
+        }
+    }
+
+    @Test
+    public void putWithSameDerivableKeyReplacesExistingEntry() {
+        PhasedHeapFriendlyHashMap<String, Integer> map = new PhasedHeapFriendlyHashMap<String, Integer>();
+
+        Integer one1 = new Integer(1);
+        Integer one2 = new Integer(1);
+
+        map.beginDataSwapPhase(1);
+        map.put("1", one1);
+        map.endDataSwapPhase();
+
+        Assert.assertSame(one1, map.get("1"));
+
+        map.beginDataSwapPhase(1);
+        map.put("1", one1);
+        map.put("1", one2);
+        map.endDataSwapPhase();
+
+        Assert.assertNotSame(one1, map.get("1"));
+        Assert.assertSame(one2, map.get("1"));
+    }
+
+    @Test
+    public void testEntrySet() {
+        PhasedHeapFriendlyHashMap<String, Integer> map = getMap(2500);
+
+        Set<Integer> allValues = new HashSet<Integer>();
+
+        for(Map.Entry<String, Integer> entry : map.entrySet()) {
+            Assert.assertEquals(String.valueOf(entry.getValue()), entry.getKey());
+            allValues.add(entry.getValue());
+        }
+
+        for(int i=0;i<2500;i++) {
+            Assert.assertTrue(allValues.contains(Integer.valueOf(i)));
+        }
+    }
+
+    @Test
+    public void testKeySet() {
+        PhasedHeapFriendlyHashMap<String, Integer> map = getMap(2500);
+
+        Set<String> allKeys = new HashSet<String>();
+
+        Set<String> keySet = map.keySet();
+
+        for(String key : keySet) {
+            Assert.assertTrue(keySet.contains(key));
+            allKeys.add(key);
+        }
+
+        for(int i=0;i<2500;i++) {
+            Assert.assertTrue(keySet.contains(String.valueOf(i)));
+            Assert.assertTrue(allKeys.contains(String.valueOf(i)));
+        }
+    }
+
+    @Test
+    public void testValueSet() {
+        PhasedHeapFriendlyHashMap<String, Integer> map = getMap(2500);
+
+        Set<Integer> allKeys = new HashSet<Integer>();
+
+        Collection<Integer> values = map.values();
+
+        for(Integer value : values) {
+            Assert.assertTrue(values.contains(value));
+            allKeys.add(value);
+        }
+
+        for(int i=0;i<2500;i++) {
+            Assert.assertTrue(values.contains(Integer.valueOf(i)));
+            Assert.assertTrue(allKeys.contains(Integer.valueOf(i)));
+        }
+    }
+
+    @Test
+    public void testImproperPut() {
+        boolean exceptionThrown = false;
+
+        PhasedHeapFriendlyHashMap<String, Integer> map = new PhasedHeapFriendlyHashMap<String, Integer>();
+
+        try {
+            map.put("1", 1);
+        } catch (IllegalStateException e) {
+            exceptionThrown = true;
+        }
+
+        Assert.assertTrue(exceptionThrown);
+    }
+
+    @Test
+    public void testImproperGet() {
+
+        PhasedHeapFriendlyHashMap<String, Integer> map = new PhasedHeapFriendlyHashMap<String, Integer>();
+
+        map.beginDataSwapPhase(1);
+        map.put("1", 1);
+
+        Assert.assertNull(map.get("1"));
+
+        map.endDataSwapPhase();
+
+        Assert.assertNotNull(map.get("1"));
+    }
+
+    @Test
+    public void testImproperBeginSwapPhase() {
+        boolean exceptionThrown = false;
+
+        PhasedHeapFriendlyHashMap<String, Integer> map = new PhasedHeapFriendlyHashMap<String, Integer>();
+
+        map.beginDataSwapPhase(1);
+
+        try {
+            map.beginDataSwapPhase(1);
+        } catch (IllegalStateException e) {
+            exceptionThrown = true;
+        }
+
+        Assert.assertTrue(exceptionThrown);
+    }
+
+    @Test
+    public void testImproperEndSwapPhase() {
+        boolean exceptionThrown = false;
+
+        PhasedHeapFriendlyHashMap<String, Integer> map = new PhasedHeapFriendlyHashMap<String, Integer>();
+
+        try {
+            map.endDataSwapPhase();
+        } catch (IllegalStateException e) {
+            exceptionThrown = true;
+        }
+
+        Assert.assertTrue(exceptionThrown);
+    }
+
+    private PhasedHeapFriendlyHashMap<String, Integer> getMap(int numOfEntries){
+        PhasedHeapFriendlyHashMap<String, Integer> map = new PhasedHeapFriendlyHashMap<String, Integer>();
+
+        map.beginDataSwapPhase(numOfEntries);
+
+        for (int i = 0; i < numOfEntries; i++) {
+            map.put(String.valueOf(i), i);
+        }
+
+        map.endDataSwapPhase();
+
+        return map;
+    }
+}

--- a/src/test/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMapTest.java
+++ b/src/test/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMapTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 /**
  * JUnit tests for {@link PhasedHeapFriendlyHashMap}
  *
- * @author darrenbathgate
+ * @author drbathgate
  *
  */
 public class PhasedHeapFriendlyHashMapTest {

--- a/src/test/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMapTest.java
+++ b/src/test/java/com/netflix/zeno/util/collections/heapfriendly/PhasedHeapFriendlyHashMapTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2013 Netflix, Inc.
+ *  Copyright 2015 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * JUnit tests for {@link PhasedHeapFriendlyHashMap}
+ *
+ * @author darrenbathgate
+ *
+ */
 public class PhasedHeapFriendlyHashMapTest {
 
     @Test


### PR DESCRIPTION
Added an implementation of Map that wraps a HeapFriendlyHashMap.
This implementation manages the HeapFriendlyMapArrayRecycler internally by exposing methods for entering and leaving a data swap phase.